### PR TITLE
Add coverage calculation for tests. Simplify state_to_code. rename the base constant

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --color
+--order random

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 # Add dependencies required to use your gem here.
 # Example:
 #   gem "activesupport", ">= 2.3.5"

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ source "http://rubygems.org"
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 group :development do
-  gem "rspec", "~> 2.8.0"
-  gem "yard", "~> 0.7"
-  gem "bundler", ">= 1.0.0"
-  gem "jeweler", "~> 1.8.4"
+  gem "rspec"
+  gem "yard"
+  gem "bundler"
+  gem "jeweler"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,7 @@ group :development do
   gem "bundler"
   gem "jeweler"
 end
+
+group :test do
+  gem "simplecov"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ Jeweler::Tasks.new do |gem|
   gem.name = "us_states"
   gem.homepage = "http://github.com/byronanderson/us_states"
   gem.license = "MIT"
-  gem.summary     = "A module containing a list of all of the united states and territories"
+  gem.summary     = "A module containing a list of all of the United States and territories"
   gem.description = "As simple as that"
   gem.email = "byron@nationbuilder.com"
   gem.authors = ["Byron Anderson", "Jim Gilliam"]

--- a/lib/us_states.rb
+++ b/lib/us_states.rb
@@ -84,3 +84,5 @@ module UsStates
 
   STATE_TO_CODE = Hash[CODES.values.map(&:downcase).zip(CODES.keys)]
 end
+
+State = UsStates

--- a/lib/us_states.rb
+++ b/lib/us_states.rb
@@ -82,9 +82,5 @@ module UsStates
 
   private
 
-  STATE_TO_CODE = CODES.inject({}) do |hash, code_state|
-    code, state = code_state
-    hash[state.downcase] = code
-    hash
-  end
+  STATE_TO_CODE = Hash[CODES.values.map(&:downcase).zip(CODES.keys)]
 end

--- a/lib/us_states.rb
+++ b/lib/us_states.rb
@@ -1,4 +1,4 @@
-module State
+module UsStates
   class InvalidState < RuntimeError; end
 
   CODES = {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,3 @@ require 'simplecov'
 SimpleCov.start
 
 require 'us_states'
-
-# Requires supporting files with custom matchers and macros, etc,
-# in ./support/ and its subdirectories.
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,8 @@
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
-$LOAD_PATH.unshift(File.dirname(__FILE__))
-require 'rspec'
+require 'simplecov'
+SimpleCov.start
+
 require 'us_states'
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
-
-RSpec.configure do |config|
-  
-end

--- a/spec/us_states_spec.rb
+++ b/spec/us_states_spec.rb
@@ -1,4 +1,4 @@
-require 'us_states'
+require 'spec_helper'
 
 describe UsStates do
   describe ".normalize" do

--- a/spec/us_states_spec.rb
+++ b/spec/us_states_spec.rb
@@ -1,19 +1,19 @@
 require 'us_states'
 
-describe State do
+describe UsStates do
   describe ".normalize" do
-    specify { State.normalize("Alabama").should == "AL" }
-    specify { State.normalize("AL").should == "AL" }
-    specify { State.normalize("texas").should == "TX" }
+    specify { UsStates.normalize("Alabama").should == "AL" }
+    specify { UsStates.normalize("AL").should == "AL" }
+    specify { UsStates.normalize("texas").should == "TX" }
     specify do
-      expect { State.normalize("south") }.to raise_error(State::InvalidState)
+      expect { UsStates.normalize("south") }.to raise_error(UsStates::InvalidState)
     end
-    specify { State.normalize("tx").should == "TX" }
+    specify { UsStates.normalize("tx").should == "TX" }
   end
 
   describe ".member?" do
-    specify { State.member?("AL").should be_true }
-    specify { State.member?("XT").should be_false }
-    specify { State.member?("Alabama").should be_true }
+    specify { UsStates.member?("AL").should be_true }
+    specify { UsStates.member?("XT").should be_false }
+    specify { UsStates.member?("Alabama").should be_true }
   end
 end

--- a/us_states.gemspec
+++ b/us_states.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Byron Anderson", "Jim Gilliam"]
-  s.date = "2012-09-29"
+  s.date = "2013-01-18"
   s.description = "As simple as that"
   s.email = "byron@nationbuilder.com"
   s.extra_rdoc_files = [
@@ -33,27 +33,27 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.24"
-  s.summary = "A module containing a list of all of the united states and territories"
+  s.summary = "A module containing a list of all of the United States and territories"
 
   if s.respond_to? :specification_version then
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<rspec>, ["~> 2.8.0"])
-      s.add_development_dependency(%q<yard>, ["~> 0.7"])
-      s.add_development_dependency(%q<bundler>, [">= 1.0.0"])
-      s.add_development_dependency(%q<jeweler>, ["~> 1.8.4"])
+      s.add_development_dependency(%q<rspec>, [">= 0"])
+      s.add_development_dependency(%q<yard>, [">= 0"])
+      s.add_development_dependency(%q<bundler>, [">= 0"])
+      s.add_development_dependency(%q<jeweler>, [">= 0"])
     else
-      s.add_dependency(%q<rspec>, ["~> 2.8.0"])
-      s.add_dependency(%q<yard>, ["~> 0.7"])
-      s.add_dependency(%q<bundler>, [">= 1.0.0"])
-      s.add_dependency(%q<jeweler>, ["~> 1.8.4"])
+      s.add_dependency(%q<rspec>, [">= 0"])
+      s.add_dependency(%q<yard>, [">= 0"])
+      s.add_dependency(%q<bundler>, [">= 0"])
+      s.add_dependency(%q<jeweler>, [">= 0"])
     end
   else
-    s.add_dependency(%q<rspec>, ["~> 2.8.0"])
-    s.add_dependency(%q<yard>, ["~> 0.7"])
-    s.add_dependency(%q<bundler>, [">= 1.0.0"])
-    s.add_dependency(%q<jeweler>, ["~> 1.8.4"])
+    s.add_dependency(%q<rspec>, [">= 0"])
+    s.add_dependency(%q<yard>, [">= 0"])
+    s.add_dependency(%q<bundler>, [">= 0"])
+    s.add_dependency(%q<jeweler>, [">= 0"])
   end
 end
 

--- a/us_states.gemspec
+++ b/us_states.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Byron Anderson", "Jim Gilliam"]
-  s.date = "2013-01-18"
+  s.date = "2013-07-26"
   s.description = "As simple as that"
   s.email = "byron@nationbuilder.com"
   s.extra_rdoc_files = [
@@ -32,11 +32,11 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/byronanderson/us_states"
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
-  s.rubygems_version = "1.8.24"
+  s.rubygems_version = "2.0.3"
   s.summary = "A module containing a list of all of the United States and territories"
 
   if s.respond_to? :specification_version then
-    s.specification_version = 3
+    s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_development_dependency(%q<rspec>, [">= 0"])


### PR DESCRIPTION
This makes a change from `State` to `UsStates` to reflect the name of the file, the gem, and to prevent name collisions with other libraries.

I did add `State = UsStates` however so that it is backwards compatible.
